### PR TITLE
Add some configs to irb sessions

### DIFF
--- a/irbrc
+++ b/irbrc
@@ -1,0 +1,20 @@
+require 'awesome_print'
+AwesomePrint.irb!
+
+def efind(email)
+  User.find_by_email(email)
+end
+
+def u
+  User.first
+end
+
+def dj
+  Delayed::Job
+end
+
+class Object
+  def interesting_methods
+    (self.methods - Object.new.methods).sort
+  end
+end

--- a/pryrc
+++ b/pryrc
@@ -1,0 +1,2 @@
+require 'awesome_print'
+AwesomePrint.pry!


### PR DESCRIPTION
Reason for change:
* I'm constantly wanting the [`awesome_print`][3] gem for `puts`ing things out
* But it requires `require 'awesome_print'` and then `ap object_name`

What the change was:
* No more! Now _everything_ is awesome printed!
* Add an `.irbrc` file which automatically uses `ap` ([docs][1])
* Add an `.pryrc` file which automatically uses `ap` ([docs][2])
* Add some methods I always use

[1]: https://github.com/michaeldv/awesome_print#irb-integration
[2]: https://github.com/michaeldv/awesome_print#pry-integration
[3]: https://github.com/michaeldv/awesome_print