### PR TITLE
Add a "good morning" script

### DIFF
--- a/aliases
+++ b/aliases
@@ -93,6 +93,8 @@ alias tma='tmux attach -t'
 
 # Homebrew
 alias brew_update_all='brew update && brew upgrade --all && brew cleanup'
+alias vim_update_plugins='vim +PluginUpdate +qall'
+alias good_morning='brew_update_all && vim_update_plugins'
 
 # Misc
 alias -g L='| wc -l'


### PR DESCRIPTION
Reason for change:
* Every day, I update homebrew and Vim's plugins separately.
* I wrote a script for homebrew, but not for Vim.

What the change was:
* Turns out you can send commands to Vim from the CLI.
* So I added a `good_morning` alias which updates homebrew AND Vim via Vundle