### PR TITLE
Add jump alias and autocomplete

### DIFF
--- a/aliases
+++ b/aliases
@@ -81,6 +81,9 @@ alias mkdir='mkdir -p'
 alias s='cd ..'
 alias tr='tree -L 2'
 
+# Jump to different marked folders
+# https://github.com/flavio/jump
+alias j='jump'
 
 # Tail logs
 alias tlf='tail -f'

--- a/zshrc
+++ b/zshrc
@@ -114,3 +114,6 @@ fi
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
+
+# Jump stuff
+source `jump-bin --zsh-integration`


### PR DESCRIPTION
Reason for Change
=================
* I'm using the `jump` gem now to pop around to different directories.

Changes
=======
* This adds an alias for `j` to jump.
* Also adds some config to `.zshrc` to do some autocompletion.

https://github.com/flavio/jump