### PR TITLE
Use relative reference for gitignore

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -38,7 +38,7 @@
 
 [core]
   ignorecase = true
-  excludesfile = /Users/adarsh/.gitignore_global
+  excludesfile = ~/.gitignore_global
   whitespace = trailing-space,space-before-tab
 
 [apply]


### PR DESCRIPTION
Reason for Change
=================
* On some machines I use, the path to home is different.
* This makes the `.gitignore` reference brittle.

Changes
=======
* Use `~` instead of an absolute file path.