### PR TITLE
Show local time in tmux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -46,7 +46,7 @@ set -g status-interval 1
 set -g status-left '#[default][#S]'
 
 # Set right-side status bar content
-set -g status-right '#[default]%I:%M %p   %h %d %Y '
+set -g status-right "#(TZ=America/Los_Angeles date +%%I:%%M) %p   %h %d %Y "
 
 # Increase scrollback lines
 set -g history-limit 10000


### PR DESCRIPTION
Reason for Change
=================
* When using VMs without TZ's set, I get to pretend I live in UTC.

Changes
=======
* Specify the timezone as a local ENV.

http://unix.stackexchange.com/a/115812/62804