### PR TITLE
Format Git Commit Messages

### DIFF
--- a/vim/ftplugin/gitcommit.vim
+++ b/vim/ftplugin/gitcommit.vim
@@ -1,0 +1,11 @@
+" Vim filetype plugin
+" Language: git commit file
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1 " Don't load twice in one buffer
+
+" Don't break lines with a newline and comment character
+setlocal formatoptions=roq formatoptions-=t wrap linebreak nolist


### PR DESCRIPTION
Reason for Change
=================
* When writing git commit message (like this one), I use asterisks to create markdown bullets.
* When typing past the character limit, I get word wrapping and a new asterisk, which I don't want.

Changes
=======
* Add a `ftplugin` file, which is specific to `gitcommit` files.
* Set the `formatoptions` to `roq` which eliminates this behavior.

See `help fo-table` in Vim for more options.