### PR TITLE
Use rcrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,35 +1,5 @@
 #!/bin/sh
 
-cutstring="DO NOT EDIT BELOW THIS LINE"
+set -e
 
-for name in *; do
-  target="$HOME/.$name"
-  if [ -e $target ]; then
-    if [ ! -L $target ]; then
-      cutline=`grep -n -m1 "$cutstring" "$target" | sed "s/:.*//"`
-      if [[ -n $cutline ]]; then
-        let "cutline = $cutline - 1"
-        echo "Updating $target"
-        head -n $cutline "$target" > update_tmp
-        startline=`tail -r "$name" | grep -n -m1 "$cutstring" | sed "s/:.*//"`
-        if [[ -n $startline ]]; then
-          tail -n $startline "$name" >> update_tmp
-        else
-          cat "$name" >> update_tmp
-        fi
-        mv update_tmp "$target"
-      else
-        echo "WARNING: $target exists but is not a symlink."
-      fi
-    fi
-  else
-    if [[ $name != 'install.sh' ]]; then
-      echo "Creating $target"
-      if [[ -n `grep "$cutstring" "$name"` ]]; then
-        cp "$PWD/$name" "$target"
-      else
-        ln -s "$PWD/$name" "$target"
-      fi
-    fi
-  fi
-done
+RCRC=rcrc rcup -v

--- a/rcrc
+++ b/rcrc
@@ -1,0 +1,3 @@
+# Hey rcm: Don't copy things which match these dirs, only symlink them
+SYMLINK_DIRS="bundle session"
+EXCLUDES="README.md rubocop.maybe.yml install.sh"

--- a/rubocop.maybe.yml
+++ b/rubocop.maybe.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+    - '*/bin/stubs/**/*'


### PR DESCRIPTION
Reason for Change
=================
* [`rcrc`] manages symlinking much more efficiently than I do.

[`rcrc`]: https://github.com/thoughtbot/rcm

Changes
=======
* Add an `rcrc` to configure `rcm` excludes and things not to symlink.
* Update the install script to use `rcm`.

Minor
-----
* Copy a more recent `rubocop.yml` just for posterity.

Addresses #21