### PR TITLE
Add sourcing of custom aliases

### DIFF
--- a/aliases
+++ b/aliases
@@ -116,3 +116,6 @@ alias notify='terminal-notifier -message'
 
 # Edit aliases and source them afterward.
 alias aliases='vi ~/.aliases; source ~/.aliases'
+
+# Include custom aliases
+[[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
Reason for Change
=================
* Client-specific machines often have custom aliases. These should not be checked in.

Changes
=======
* Source a `.aliases.local` file if it exists.