### PR TITLE
Add a Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,30 @@
+# Qt5 for capybara-webkit
+brew 'qt5'
+
+# The recommended way to use Heroku
+brew 'heroku-toolbelt'
+
+# colorful diffs (alias diff='colordiff -u')
+brew 'colordiff'
+
+# a better ack/grep
+brew 'the_silver_searcher'
+
+# It's vim
+brew 'mercurial'
+brew 'vim'
+
+# Syntax highlighting...for ZSH!
+brew 'zsh-syntax-highlighting'
+
+# rcm for managing dotfiles
+tap 'thoughtbot/formulae'
+brew 'rcm'
+
+# Use homebrew to install OS X things
+tap 'caskroom/cask'
+brew 'brew-cask'
+
+# cask 'alfred'
+# cask 'dropbox'
+# cask 'google-chrome'

--- a/aliases
+++ b/aliases
@@ -1,6 +1,10 @@
 # Vim
 alias v='vim'
 
+#########
+# Rails #
+#########
+
 # Local servers
 alias fs='clear && forego start -p 3000'
 alias rs='rails server'
@@ -19,6 +23,10 @@ alias remongrate='rake mongoid:migrate && rake mongoid:migrate:redo'
 alias be='bundle exec'
 alias bake='bundle exec rake'
 alias bmr='bundle && migrate && time rake'
+
+#######
+# Git #
+#######
 
 # git
 alias g='git'
@@ -61,8 +69,12 @@ function gcam() {
  git commit -am $1 && git push
 }
 
-# middlman
+# middleman
 alias mm='middleman'
+
+#########
+# Shell #
+#########
 
 # Command line utils
 alias -g G='| grep'
@@ -80,6 +92,7 @@ alias ln='ln -v'
 alias mkdir='mkdir -p'
 alias s='cd ..'
 alias tr='tree -L 2'
+alias diff='colordiff'
 
 # Jump to different marked folders
 # https://github.com/flavio/jump
@@ -113,6 +126,10 @@ alias deploy-production='git push production && hk run rake db:migrate -a produc
 
 # Quick terminal notifications via https://github.com/alloy/terminal-notifier
 alias notify='terminal-notifier -message'
+
+########
+# Meta #
+########
 
 # Edit aliases and source them afterward.
 alias aliases='vi ~/.aliases; source ~/.aliases'

--- a/install
+++ b/install
@@ -2,8 +2,24 @@
 
 set -e
 
+echo "Installing Homebrew packages..."
+brew update
+brew tap homebrew/bundle
+brew bundle
+
+brew unlink qt 2>/dev/null || true
+brew link --force qt5
+
+echo "Linking dotfiles into ~ ..."
+# Before `rcup` runs, there is no ~/.rcrc, so we must tell `rcup` where to look.
+# We need the rcrc because it tells `rcup` to ignore thousands of useless Vim
+# backup files that slow it down significantly.
+
 # Remove everything in there now, using `rcrc` as the rcrc.
 RCRC=rcrc rcdn -v
 
 # Install everything, using `rcrc` as the rcrc.
 RCRC=rcrc rcup -v
+
+echo "Installing Vim packages..."
+vim +PlugInstall +qa

--- a/zshrc
+++ b/zshrc
@@ -123,3 +123,6 @@ BASE="$HOME/.zsh"
 for file in "$BASE"/*.zsh; do
   source "$file"
 done
+
+# Add zsh-syntax-highlighting
+source /usr/local/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
Reason for Change
=================
* I use [homebrew] extensively to install various CLI tools.
* It's dumb to remember which ones. Might as well centralize them.

[homebrew]: http://brew.sh/

Changes
=======
* Add a `Brewfile` with some stuff in it.
* Add some cask lines to install OS X apps.
* Add the appropriate lines to the `install` script.

Related
-------
* Add alias for `colordiff`.
* Use `zsh-syntax-highlisting` and add the source to the bottom of the `zshrc`.

Minor
-----
* Add sections to the `zshrc`.
* Correct 'middleman' typo.

Addresses https://github.com/adarsh/dotfiles/issues/26