### PR TITLE
Use master for vim-prosession

### DIFF
--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -16,7 +16,7 @@ Plug 'sjl/gundo.vim'
 Plug 'slim-template/vim-slim'
 Plug 'tpope/vim-fugitive'
 Plug 'tpope/vim-markdown'
-Plug 'tpope/vim-obsession' | Plug 'dhruvasagar/vim-prosession', { 'tag': 'v0.5.5' }
+Plug 'tpope/vim-obsession' | Plug 'dhruvasagar/vim-prosession'
 Plug 'tpope/vim-rails'
 Plug 'tpope/vim-surround'
 Plug 'vim-airline/vim-airline'


### PR DESCRIPTION
Reason for Change
=================
* Issue is fixed.

Change
======
* Remove version lock for `vim-prosession`. Master seems stable now.

https://github.com/dhruvasagar/vim-prosession/issues/23#issuecomment-206572563