### PR TITLE
Add diff-so-fancy for fancier git diffs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,6 +7,9 @@ brew 'heroku-toolbelt'
 # colorful diffs (alias diff='colordiff -u')
 brew 'colordiff'
 
+# Fancier git diffs
+brew 'diff-so-fancy'
+
 # a better ack/grep
 brew 'the_silver_searcher'
 

--- a/gitconfig
+++ b/gitconfig
@@ -37,9 +37,11 @@
   helper = osxkeychain
 
 [core]
+  editor = vim
   ignorecase = true
   excludesfile = ~/.gitignore_global
   whitespace = trailing-space,space-before-tab
+  pager = diff-so-fancy | less -R --tabs=1,5
 
 [apply]
   whitespace = warn


### PR DESCRIPTION
Reason for Change
=================
* Being fancy!

Changes
=======
* Add `diff-so-fancy` to the `Brewfile`.
* Configure the git pager to use `diff-so-fancy`.

Minor
-----
* Let git know Vim is the editor of choice.

Addresses https://github.com/adarsh/dotfiles/issues/38

Inspiration: https://github.com/christoomey/dotfiles/issues/114


![fc007e74-04d3-11e6-88ea-916c7ad24ed2](https://cloud.githubusercontent.com/assets/913757/14618677/a2e9a15e-0568-11e6-85de-bf6e74e6f215.png)
