### PR TITLE
Update diff-so-fancy to remove empty line blocks

### DIFF
--- a/bin/lib/diff-so-fancy.pl
+++ b/bin/lib/diff-so-fancy.pl
@@ -7,9 +7,9 @@ use File::Basename;
 my $remove_file_add_header    = 1;
 my $remove_file_delete_header = 1;
 my $clean_permission_changes  = 1;
-my $change_hunk_indicators    = 1;
-my $strip_leading_indicators  = 1;
-my $mark_empty_lines          = 1;
+my $change_hunk_indicators    = git_config_boolean("diff-so-fancy.changeHunkIndicators","true");
+my $strip_leading_indicators  = git_config_boolean("diff-so-fancy.stripLeadingSymbols","true");
+my $mark_empty_lines          = git_config_boolean("diff-so-fancy.markEmptyLines","true");
 
 #################################################################################
 
@@ -168,13 +168,96 @@ sub mark_empty_line {
 	return $line;
 }
 
+sub boolean {
+	my $str = shift();
+	$str    = trim($str);
+
+	if ($str eq "" || $str =~ /^(no|false|0)$/i) {
+		return 0;
+	} else {
+		return 1;
+	}
+}
+
+# Memoize getting the git config
+{
+	my $static_config;
+
+	sub git_config_raw {
+		if ($static_config) {
+			# If we already have the config return that
+			return $static_config;
+		}
+
+		my $cmd = "git config --list";
+		my @out = `$cmd`;
+
+		$static_config = \@out;
+
+		return \@out;
+	}
+}
+
+# Fetch a textual item from the git config
+sub git_config {
+	my $search_key    = lc($_[0] // "");
+	my $default_value = lc($_[1] // "");
+
+	my $out = git_config_raw();
+
+	# If we're in a unit test, use the default (don't read the users config)
+	if (in_unit_test()) {
+		return $default_value;
+	}
+
+	my $raw = {};
+	foreach my $line (@$out) {
+		if ($line =~ /=/) {
+			my ($key,$value) = split("=",$line,2);
+			$value =~ s/\s+$//;
+			$raw->{$key} = $value;
+		}
+	}
+
+	# If we're given a search key return that, else return the hash
+	if ($search_key) {
+		return $raw->{$search_key} // $default_value;
+	} else {
+		return $raw;
+	}
+}
+
+# Fetch a boolean item from the git config
+sub git_config_boolean {
+	my $search_key    = lc($_[0] // "");
+	my $default_value = lc($_[1] // 0); # Default to false
+
+	# If we're in a unit test, use the default (don't read the users config)
+	if (in_unit_test()) {
+		return $default_value;
+	}
+
+	my $result = git_config($search_key,$default_value);
+	my $ret    = boolean($result);
+
+	return $ret;
+}
+
+# Check if we're inside of BATS
+sub in_unit_test {
+	if ($ENV{BATS_CWD}) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
 # Return git config as a hash
-sub get_git_config {
-	my $cmd = "git config --list";
-	my @out = `$cmd`;
+sub get_git_config_hash {
+	my $out = git_config_raw();
 
 	my %hash;
-	foreach my $line (@out) {
+	foreach my $line (@$out) {
 		my ($key,$value) = split("=",$line,2);
 		$value =~ s/\s+$//;
 		my @path = split(/\./,$key);
@@ -246,4 +329,12 @@ sub bleach_text {
 	$str    =~ s/\e\[\d*(;\d+)*m//mg;
 
 	return $str;
+}
+
+sub trim {
+	my $s = shift();
+	if (!$s) { return ""; }
+	$s =~ s/^\s*|\s*$//g;
+
+	return $s;
 }

--- a/gitconfig
+++ b/gitconfig
@@ -36,6 +36,9 @@
 [credential]
   helper = osxkeychain
 
+[diff-so-fancy]
+  markEmptyLines = false
+
 [core]
   editor = vim
   ignorecase = true


### PR DESCRIPTION
Reason for Change
=================
* diff-so-fancy, while awesome, dropped a colored block if there was a deleted or added newline.
* It's distracting to my small brain, so I wanted to remove it.
* In a recent version, a git config option was added to `diff-so-fancy` to disable this blockiness.

Changes
=======
* Pull down the most recent version of `bin/diff-so-fancy.pl`.
* Set the git config to disable the empty-line-block thingy.

https://github.com/so-fancy/diff-so-fancy


Before:
![image](https://cloud.githubusercontent.com/assets/913757/15332842/188463da-1c1c-11e6-82a4-eff04f5cb46f.png)

After:
![image](https://cloud.githubusercontent.com/assets/913757/15332868/31f03d58-1c1c-11e6-916c-bbb840d4d6da.png)
