### PR TITLE
Use my fork of tomorrow-night-eighties colorscheme

### DIFF
--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -1,6 +1,7 @@
 " Plugins I am experimenting with:
 
 Plug 'AndrewRadev/splitjoin.vim'
+Plug 'adarsh/vim-tomorrow-theme'
 Plug 'benmills/vimux'
 Plug 'christoomey/vim-tmux-navigator'
 Plug 'dietsche/vim-lastplace'
@@ -14,7 +15,6 @@ Plug 'rking/ag.vim'
 Plug 'scrooloose/syntastic'
 Plug 'sjl/gundo.vim'
 Plug 'slim-template/vim-slim'
-Plug 'taecilla/fairyfloss.vim'
 Plug 'tpope/vim-fugitive'
 Plug 'tpope/vim-markdown'
 Plug 'tpope/vim-obsession' | Plug 'dhruvasagar/vim-prosession'

--- a/vimrc
+++ b/vimrc
@@ -71,7 +71,7 @@ if executable("ag")
 endif
 
 " Color scheme
-colorscheme fairyfloss
+colorscheme Tomorrow-Night-Eighties
 highlight NonText guibg=#060606
 
 " Numbers

--- a/zshrc
+++ b/zshrc
@@ -117,6 +117,9 @@ fi
 # enable colored output from ls, etc
 export CLICOLOR=1
 
+# Set colors to match iTerm2 Terminal Colors
+export TERM=xterm-256color
+
 # Source everything in the zsh directory
 BASE="$HOME/.zsh"
 


### PR DESCRIPTION
Reason for Change
=================
* Turns out fairyfloss.vim does not have syntax highlighting set up well for Ruby :/
* I liked `tomorrow-night-eighties` and wanted to use that.
* Also turns out I was mis-configuring my terminal emulation for iTerm2.

Changes
=======
* Add [my fork of `vim-tomorrow-theme`][1] as a plugin. I forked it to set the background color to `#000000`.
* Remove `fairyfloss`.
* Set the `TERM` variable correctly for iTerm2

[1]: https://github.com/adarsh/vim-tomorrow-theme