### PR TITLE
alias git ss > `diff --shortstat`

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -37,17 +37,19 @@
   q = rebase -i origin/master
   rc = rebase --continue
   sh = show
+
   unstage = reset HEAD
   wip = commit -m 'fixup! wip [ci skip]' && push
-
-  # Delete a branch both locally and on the server
-  delete-branch = !sh -c 'git push origin :refs/heads/$1 && git remote prune origin && git branch -D $1' -
-
-  # Merge the branch you are on, push, and copy last branchname to pb
-  down = !git checkout master && git merge @{-1} --ff-only && git name-rev --name-only @{-1} | pbcopy && git push
   pr = !git log -n 1 --pretty=format:'%s%n%n%b' | hub pull-request -F -
   squash = !git rebase -i origin/master
   up = !git fetch origin && git rebase origin/master
+  ss = diff --shortstat origin/master
+
+  # Merge the branch you are on, push, and copy last branchname to the PasteBoard
+  down = !git checkout master && git merge @{-1} --ff-only && git name-rev --name-only @{-1} | pbcopy && git push
+
+  # Delete a branch both locally and on the server
+  delete-branch = !sh -c 'git push origin :refs/heads/$1 && git remote prune origin && git branch -D $1' -
 
 [credential]
   helper = osxkeychain


### PR DESCRIPTION
Reason for Change
=================
From @thorncp's [PR][1]:

> When working on a feature branch, I often stop to check in on my current diff size, to judge whether I should make an attempt to submit a pull request with the work done so far, or continue implementing the feature.  I don't have any hard limits, but usually when a diff is in the ballpark of 300 line changes, I'll make an attempt to submit a PR with those isolated changes.
>
> Note: this will only calculate stats for files already in the index, e.g. new files won't be included unless they are added with `git add -N` first.

> Note: to calculate these stats on changes that have been staged, execute `git ss --cached`. I don't think I do this often enough to warrant an alias for it.

Changes
=======
* Add an alias to return the stats of the diff vs. master.

Minor
=====
* Shuffle some aliases around.

[1]: https://github.com/thorncp/dotfiles/pull/5