### PR TITLE
Always reload changed files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -167,3 +167,6 @@ set winheight=999
 " Don't remove curly braces when splitting a hash.
 let g:splitjoin_ruby_curly_braces = 1
 let g:splitjoin_ruby_hanging_args = 0
+
+" Don't ask me if I want to load changed files. The answer is always 'Yes'
+set autoread


### PR DESCRIPTION
Reason for Change
=================
* When vim detects that a file has been changed, it politely asks you if you want to load the new file.
* The answer is always yes, so this should probably be a default.
* Hat tip to @gabebwe (Here: https://github.com/gabebw/dotfiles/commit/4b6c41068f8354f823b593a976e698d19149c16f) and @jcmorrow

Changes
=======
* Set `autoread`.