### PR TITLE
Clear the screen before each command

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -89,3 +89,9 @@ function precmd {
   vcs_info
   git status 2> /dev/null >! "/tmp/git-status-$$"
 }
+
+# Clear the screen before each command using the preexec hook function.
+# http://zsh.sourceforge.net/Doc/Release/Functions.html
+function preexec {
+  clear
+}


### PR DESCRIPTION
Reason for Change
=================
* After looking through my shell history, I noticed I clear the screen a great deal to not confuse myself.
* I rarely need to look at the output from two subsequent commands at the same time.

Changes
=======
* Add a `preexec` function which runs `clear` "just after a command has been read and is about to be executed."
From the man page:

> If the history mechanism is active (regardless of whether the line was discarded from the history buffer), the string that the user typed is passed as the first argument, otherwise it is an empty string. The actual command that will be executed (including expanded aliases) is passed in two different forms: the second argument is a single-line, size-limited version of the command (with things like function bodies elided); the third argument contains the full text that is being executed.

http://zsh.sourceforge.net/Doc/Release/Functions.html