### PR TITLE
Fix vim copy/paste in tmux broken by Sierra

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,6 +1,12 @@
 # Set default terminal emulation to xterm
 set -g default-terminal 'xterm-256color'
 
+# Set the default terminal and copy-paste behavior
+set -g default-shell $SHELL
+
+# Be explicit about the reattaching of user namespace
+set -g default-command "reattach-to-user-namespace -l ${SHELL}"
+
 # Act like vim
 setw -g mode-keys vi
 bind h select-pane -L


### PR DESCRIPTION
Reason for Change
=================
* Sierra broke the `reattach-to-user-namespace` behavior.

Changes
=======
* Use the fix mentioned [here][1].

[1]: https://github.com/tmux/tmux/issues/543#issuecomment-248980734