### PR TITLE
Remove unnecessary flag from homebrew's upgrade

### DIFF
--- a/aliases
+++ b/aliases
@@ -108,7 +108,7 @@ alias tmn='tmux new -s'
 alias tma='tmux attach -t'
 
 # Homebrew
-alias brew_update_all='brew update && brew upgrade --all && brew cleanup'
+alias brew_update_all='brew update && brew upgrade && brew cleanup'
 alias vim_update_plugins='vim +PlugUpgrade +PlugUpdate +qall'
 alias good_morning='brew_update_all && vim_update_plugins'
 


### PR DESCRIPTION
Reason for Change
=================
* Got this message from Homebrew today when running my [`good_morning`][1] script:

> Warning: We decided to not change the behaviour of `brew upgrade` so
> `brew upgrade --all` is equivalent to `brew upgrade` without any other
> arguments (so the `--all` is a no-op and can be removed).

Changes
=======
* Remove the `--all` flag from `brew upgrade`.

[1]: https://github.com/adarsh/dotfiles/blob/176791f3262a8af16ae29e64337280776a15aeca/aliases#L111-L113