### PR TITLE
Treat .etl files like Ruby

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -175,3 +175,6 @@ set autoread
 map y <Plug>(highlightedyank)
 " Highlight for 5 seconds
 let g:highlightedyank_highlight_duration = 5000
+
+" Treat .etl files like .rb
+au BufRead,BufNewFile *.etl setfiletype ruby


### PR DESCRIPTION
Reason for Change
=================
* Some [kiba][1] work I am doing leads me to create `.etl` files.
* These are Ruby, so I'm missing lots of syntax highlighting.

Changes
=======
* Ask Vim to look at `.etl` files as Ruby.