### PR TITLE
Use the latest version for Postgres.app binaries

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -97,7 +97,7 @@ export PATH="$HOME/.bin:$PATH"
 export PATH=".git/safe/../../bin:$PATH"
 
 # Paths for Postgres.app binaries
-export PATH="/Applications/Postgres.app/Contents/Versions/9.4/bin:$PATH"
+export PATH="/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH"
 
 # unset RBENV_VERSION
 # load rbenv if available


### PR DESCRIPTION
Reason for Change
=================
* The shell wasn't able to find the `dropdb` CLI tool for Postgres.app.
* The `PATH` update pointed toward a specific PG version.

Changes
=======
* Use the `\latest\` symlink, which is less brittle.

https://postgresapp.com/documentation/cli-tools.html