### PR TITLE
Use BSD find instead of ZSH mv

### DIFF
--- a/bin/clean_downloads
+++ b/bin/clean_downloads
@@ -7,4 +7,4 @@ setopt null_glob
 # Move folders and files with an mtime (modification) older than 1 week to the
 # trash folder.
 # http://www.zsh.org/mla/workers/2011/msg01399.html
-mv ~/Downloads/**/*(.mh+168) ~/.Trash/
+find ~/Downloads/* -mtime +5 -exec mv '{}' ~/.Trash \;


### PR DESCRIPTION
Reason for Change
=================
* Errors! The files wouldn't move and the logs looked confusing.
* Specifically, I got a lot of `zsh : no matches found` errors in the log, which I don't want since I run this script every minute.

Changes
=======
* Use BSD `find` and then `-exec` to `mv` files into the trash.
* Since this is OS X and zsh, we have to quote the curlies to make it work.