### PR TITLE
Use direnv for directory-specific shell config

### DIFF
--- a/gitignore_global
+++ b/gitignore_global
@@ -22,3 +22,8 @@ bin/stubs
 
 # Overcommit (https://github.com/brigade/overcommit)
 .overcommit.yml
+
+# Directory-specific zsh configuration
+.envrc
+.aliases.local
+.env.local

--- a/zshrc
+++ b/zshrc
@@ -129,3 +129,6 @@ done
 
 # Add zsh-syntax-highlighting
 source /usr/local/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+
+# Load directory-specific shell config (https://direnv.net/)
+eval "$(direnv hook zsh)"


### PR DESCRIPTION
Reason for Change
=================
* On a client project, some directory-specific aliases and `ENV`s were required.
* The proposed solution was a little aggressive, clobbering cd kind of heavily.
* This seemed a little cleaner.

Changes
=======
* Use [`direnv`][1] to load `.envrc` files, should they exist.
* Add some files to the `.gitignore_global` to avoid committing them to VC.

[1]: https://direnv.net/