### PR TITLE
Change cleanup script from mtime to atime

### DIFF
--- a/bin/clean_downloads
+++ b/bin/clean_downloads
@@ -7,4 +7,4 @@ setopt null_glob
 # Move folders and files with an mtime (modification) older than 1 week to the
 # trash folder.
 # http://www.zsh.org/mla/workers/2011/msg01399.html
-find ~/Downloads/* -mtime +5 -exec mv '{}' ~/.Trash \;
+find ~/Downloads/* -atime +5 -exec mv '{}' ~/.Trash \;


### PR DESCRIPTION
Reason for Change
=================
* I downloaded some files and they disappeared almost immediately.
* I realized the `mtime` of the file was set by the creator and was older than our threshold for the cleanup script.
* `atime` is more reasonable - when did I last look at this file?

Changes
=======
* Change `mtime` for `atime` in the `clean_downloads` script.