### PR TITLE
Vim: Remove unnecessary script sourcing

### DIFF
--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -29,7 +29,3 @@ Plug 'vim-airline/vim-airline-themes'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/ReplaceWithRegister'
 Plug 'vim-scripts/greplace.vim'
-
-" Local Plugins
-
-source ~/.vim/plugin/squirrel.vim

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -55,7 +55,7 @@ prompt_git_status() {
     print "staged"
   elif print "$git_status" | grep -qF "Untracked files"; then
     print "untracked"
-  elif print "$git_status" | grep -qF "working directory clean"; then
+  elif print "$git_status" | grep -qF "working tree clean"; then
     print "unchanged"
   fi
 }
@@ -72,7 +72,7 @@ prompt_git_status_symbol() {
     unchanged) letter=$clean;;
   esac
 
-  print "$letter"
+  print "$letter "
 }
 
 #######################


### PR DESCRIPTION
Title

Reason for Change
=================
* [As @gabebw noted thoughtfully][1], sourcing the squirrel file directly is not necessary. Vim will source everything in `~/.vim/plugin/` for me.
* Turns out I had not done an `rcup; rcdn` so the file wasn't included correctly.

[1]: https://github.com/adarsh/dotfiles/pull/68#pullrequestreview-30891855

Changes
=======
* Don't source the file explicitly.

Minor
-----
* The prompt needs a space after the new emoji.