### PR TITLE
Automatically stash unstaged changes when rebasing

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -72,3 +72,5 @@
 
 [diff]
   compactionHeuristic = true
+[rebase]
+	autoStash = true


### PR DESCRIPTION
Reason for Change
=================
From the `git` documentation:

```
Automatically create a temporary stash before the operation begins, and apply it after the operation ends. This means that you can run rebase on a dirty worktree. However, use with care: the final stash application after a successful rebase might result in non-trivial conflicts.
```

Changes
=======
* Turn on `autoStash`

https://www.praqma.com/stories/git-autostash/