### PR TITLE
Fix Vim's Rolodex mode

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -161,7 +161,7 @@ highlight ColorColumn ctermbg=7
 highlight LineNr term=underline cterm=bold ctermfg=DarkGray
 
 " Use 'Rolodex' mode with vsplits, making them all expand
-set winheight=999
+set winheight=61
 
 "" Config for SplitJoin
 " Don't remove curly braces when splitting a hash.


### PR DESCRIPTION
Reason for Change
=================
* I've set Vim to "rolodex mode" which maximizes each vsplit's height.
* This has the effect of feeling like you're flipping through a rolodex when scanning up/down windows.
* However, this will error a bit since the terminal does not have 999 rows. Setting it to something smaller is helpful.

Changes
=======
* Reduce the `winheight` setting.